### PR TITLE
RFC: implement btree::{set,map,multiset,multimap}::contains() under C++20

### DIFF
--- a/btree/btree.h
+++ b/btree/btree.h
@@ -2942,6 +2942,11 @@ public:
 	size_type count(const key_type& key) const {
 		return this->__tree.count_unique(key);
 	}
+	#if __cplusplus > 201703L
+		bool contains(const key_type& key) const {
+			return find(key) != this->end();
+		}
+	#endif
 
 	// Insertion routines.
 	std::pair<iterator, bool> insert(const value_type& x) {
@@ -3045,6 +3050,11 @@ class btree_multi_container : public btree_container<Tree> {
 	size_type count(const key_type& key) const {
 		return this->__tree.count_multi(key);
 	}
+	#if __cplusplus > 201703L
+		bool contains(const key_type& key) const {
+			return find(key) != this->end();
+		}
+	#endif
 
 	// Insertion routines.
 	iterator insert(const value_type& x) {


### PR DESCRIPTION
Hi,

thanks for this library. While using it in a C++20 codebase, I noticed that the `contains()` method, supported in the standard library for set/map/multiset, multimap, could be easily integrated.

In this way, there would be less friction when adopting the library in a pre-existing code base.

This PR contains the version I am using in my project. Do you think it makes sense to integrate it? Have I missed something glaring?

This is the rest of the commit message from the PR:

> C++20 adds support for {set,map,multiset,multimap}::contains(). See, for example https://en.cppreference.com/w/cpp/container/set/contains
>
> This change adds support for those methods, enabling it only if the compiler is C++20 compliant or newer.
>
> For reference, the following is the equivalent implementation that LLVM 11 uses in its libc++ standard library:
>
> https://github.com/llvm/llvm-project/blob/llvmorg-11.0.0/libcxx/include/set#L795-L798
> https://github.com/llvm/llvm-project/blob/llvmorg-11.0.0/libcxx/include/map#L1404-L1407