### PR TITLE
Add alternative overload for btree's operator==()

### DIFF
--- a/btree/btree.h
+++ b/btree/btree.h
@@ -958,6 +958,12 @@ public:
 	bool operator!=(const const_iterator& x) const {
 		return node != x.node || position != x.position;
 	}
+	bool operator==(const iterator& x) const {
+		return node == x.node && position == x.position;
+	}
+	bool operator!=(const iterator& x) const {
+		return node != x.node || position != x.position;
+	}
 
 	// Accessors for the key/value the iterator is pointing at.
 	const key_type& key() const {


### PR DESCRIPTION
Silence Clang's C++20 [-Wambiguous-reversed-operator](https://releases.llvm.org/11.0.0/tools/clang/docs/DiagnosticsReference.html#wambiguous-reversed-operator).