### PR TITLE
Use static_assert instead of COMPILE_ASSERT

### DIFF
--- a/btree/btree.h
+++ b/btree/btree.h
@@ -144,13 +144,6 @@ struct big_ {
 	char dummy[2];
 };
 
-// A compile-time assertion.
-template <bool>
-struct CompileAssert { };
-
-#define COMPILE_ASSERT(expr, msg) \
-	typedef CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
-
 struct btree_extract_key_fail_tag { };
 struct btree_extract_key_self_tag { };
 struct btree_extract_key_first_tag { };
@@ -191,7 +184,7 @@ struct btree_can_extract_map_key<ValueType, Key, Key, RawValueType> : std::false
 //  };
 //
 // Note that the return type is an int and not a bool. There is a
-// COMPILE_ASSERT which enforces this return type.
+// static_assert which enforces this return type.
 struct btree_key_compare_to_tag { };
 
 // A helper class that indicates if the Compare parameter is derived from
@@ -1743,17 +1736,17 @@ private:
 	// key_compare_checker() to instantiate and then figure out the size of the
 	// return type of key_compare_checker() at compile time which we then check
 	// against the sizeof of big_.
-	COMPILE_ASSERT(sizeof(key_compare_checker(key_compare_helper()(key_type(), key_type()))) == sizeof(big_),
-		key_comparison_function_must_return_bool);
+	static_assert(sizeof(key_compare_checker(key_compare_helper()(key_type(), key_type()))) == sizeof(big_),
+		"key_comparison_function_must_return_bool");
 
 	// Note: We insist on kTargetValues, which is computed from
 	// Params::kTargetNodeSize, must fit the base_fields::field_type.
-	COMPILE_ASSERT((kNodeValues < (1 << (8 * sizeof(typename base_fields::field_type)))),
-		target_node_size_too_large);
+	static_assert((kNodeValues < (1 << (8 * sizeof(typename base_fields::field_type)))),
+		"target_node_size_too_large");
 
 	// Test the assumption made in setting kNodeValueSpace.
-	COMPILE_ASSERT(sizeof(base_fields) >= 2 * sizeof(void*),
-		node_space_assumption_incorrect);
+	static_assert(sizeof(base_fields) >= 2 * sizeof(void*),
+		"node_space_assumption_incorrect");
 };
 
 ////


### PR DESCRIPTION
Implements the fix described in (https://code.google.com/archive/p/cpp-btree/issues/22) for improving compatibility with MSVC.